### PR TITLE
[DSD-9196] Image transfer from mosipdev2 to mosipqa

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -1,3 +1,1 @@
-mosipdev/pmp-revamp-ui:release-1.2.2.x 1.2.2.x
-mosipdev/partner-management-service:release-1.2.2.x 1.2.2.x
-mosipdev/policy-management-service:release-1.2.2.x 1.2.2.x
+mosipdev2/inji-certify-with-plugins:release-0.13.x 0.13.x


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images in release configuration by replacing legacy service images with a new certification service image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->