### PR TITLE
[DSD-9303] Image transfer from dev to dev2

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -1,1 +1,2 @@
-mosipdev2/apitest-masterdata:release-1.2.1.x 1.2.1.x
+mosipdev/dsl-orchestrator:release-1.3.x release-1.3.x
+mosipdev/dsl-packetcreator:release-1.3.x release-1.3.x


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image configurations to include two new release 1.3.x versions (dsl-orchestrator and dsl-packetcreator) while removing a deprecated 1.2.1.x entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->