### PR TITLE
Image transfer from mosipint to mosipid

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -1,1 +1,2 @@
-mosipdev2/inji-certify-with-plugins:release-0.13.x 0.13.x
+mosipint/zookeeper:3.9.1-debian-12-r13 3.9.1-debian-12-r13
+mosipint/kafka:3.6.1-debian-12-r12 3.6.1-debian-12-r12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Zookeeper to version 3.9.1-debian-12-r13
  * Updated Kafka to version 3.6.1-debian-12-r12
  * Removed deprecated image entry for inji-certify-with-plugins release 0.13.x

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->