### PR TITLE
[DSD-9524] 1.2.1.0 Platform GA release

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -65,7 +65,6 @@ mosipdev/consolidator-websub-service:release-1.3.x 1.3.0
 mosipdev/data-share-service:release-1.3.x 1.3.0
 mosipdev/pre-registration-ui:release-1.3.x 1.3.0
 mosipdev/mosip-file-server:release-1.3.x 1.3.0
-mosipdev/mosip-jboss-keycloak:release-1.3.x 1.3.0
 mosipdev/keycloak-init:release-1.3.x 1.3.0
 mosipdev/mosip-artemis-keycloak:release-1.3.x 1.3.0
 mosipdev/digital-card-service:release-1.3.x 1.3.0


### PR DESCRIPTION
Removed entry for mosipdev/mosip-jboss-keycloak from images.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated image entry from release build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->