### PR TITLE
[DSD-9774] Image transfer from dev2 to qa .

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -1,1 +1,4 @@
-injistackdev/inji-certify-with-plugins:release-0.14.x release-0.14.x
+injistackdev2/inji-verify-service:release-0.17.x 0.17.x
+injistackdev2/inji-verify-ui:release-0.17.x 0.17.x
+injistackdev2/apitest-inji-verify:release-0.17.x 0.17.x
+injistackdev2/uitest-verify:release-0.17.x 0.17.x


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references from version 0.14.x to 0.17.x, transitioning from a single image to four component-specific images for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->