### PR TITLE
[DSD-10185] Image transfer from dev2 to qa.

### DIFF
--- a/release/vidivi/images.txt
+++ b/release/vidivi/images.txt
@@ -1,2 +1,2 @@
-mosipdev/dsl-orchestrator:release-1.2.2.x 1.2.2.0
-mosipdev/dsl-packetcreator:release-1.2.2.x 1.2.2.0
+injistackdev2/inji-verify-service:release-0.18.x 0.18.x
+injistackdev2/inji-verify-ui:release-0.18.x 0.18.x


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container image references for system infrastructure components. Removed legacy service images pinned to version 1.2.2.0 and replaced them with new service container images at version 0.18.x. This modernizes the deployment infrastructure, improves system reliability and operational consistency, and ensures current, actively maintained container images are used across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->